### PR TITLE
Update comment example for `insert` to include `RowLacks`

### DIFF
--- a/src/Data/Record.purs
+++ b/src/Data/Record.purs
@@ -75,7 +75,7 @@ modify l f r = set l (f (get l r)) r
 -- |
 -- | ```purescript
 -- | insert (SProxy :: SProxy "x")
--- |   :: forall r a. a -> { | r } -> { x :: a | r }
+-- |   :: forall r a. RowLacks "x" r => a -> { | r } -> { x :: a | r }
 -- | ```
 insert
   :: forall r1 r2 l a


### PR DESCRIPTION
Without the constraint the type in the example doesn't work.