### PR TITLE
Builder API

### DIFF
--- a/src/Data/Record/Builder.js
+++ b/src/Data/Record/Builder.js
@@ -1,0 +1,44 @@
+"use strict";
+
+exports.copyRecord = function(rec) {
+  var copy = {};
+  for (var key in rec) {
+    if ({}.hasOwnProperty.call(rec, key)) {
+      copy[key] = rec[key];
+    }
+  }
+  return copy;
+};
+
+exports.unsafeInsert = function(l) {
+  return function(a) {
+    return function(rec) {
+      rec[l] = a;
+      return rec;
+    };
+  };
+};
+
+exports.unsafeDelete = function(l) {
+  return function(rec) {
+    delete rec[l];
+    return rec;
+  };
+};
+
+exports.unsafeMerge = function(r1) {
+  return function(r2) {
+    var copy = {};
+    for (var key in r2) {
+      if ({}.hasOwnProperty.call(r2, key)) {
+        copy[key] = r2[key];
+      }
+    }
+    for (var key in r1) {
+      if ({}.hasOwnProperty.call(r1, key)) {
+        copy[key] = r1[key];
+      }
+    }
+    return copy;
+  };
+};

--- a/src/Data/Record/Builder.js
+++ b/src/Data/Record/Builder.js
@@ -29,14 +29,14 @@ exports.unsafeDelete = function(l) {
 exports.unsafeMerge = function(r1) {
   return function(r2) {
     var copy = {};
-    for (var key in r2) {
-      if ({}.hasOwnProperty.call(r2, key)) {
-        copy[key] = r2[key];
+    for (var k1 in r2) {
+      if ({}.hasOwnProperty.call(r2, k1)) {
+        copy[k1] = r2[k1];
       }
     }
-    for (var key in r1) {
-      if ({}.hasOwnProperty.call(r1, key)) {
-        copy[key] = r1[key];
+    for (var k2 in r1) {
+      if ({}.hasOwnProperty.call(r1, k2)) {
+        copy[k2] = r1[k2];
       }
     }
     return copy;

--- a/src/Data/Record/Builder.purs
+++ b/src/Data/Record/Builder.purs
@@ -1,0 +1,66 @@
+module Data.Record.Builder
+  ( Builder
+  , build
+  , insert
+  , delete
+  , merge
+  ) where
+
+import Prelude
+
+import Data.Symbol (class IsSymbol, SProxy, reflectSymbol)
+import Type.Row (class RowLacks)
+
+foreign import copyRecord :: forall r1. Record r1 -> Record r1
+foreign import unsafeInsert :: forall a r1 r2. String -> a -> Record r1 -> Record r2
+foreign import unsafeDelete :: forall r1 r2. String -> Record r1 -> Record r2
+foreign import unsafeMerge :: forall r1 r2 r3. Record r1 -> Record r2 -> Record r3
+
+-- | A `Builder` can be used to `build` a record by incrementally adding
+-- | fields in-place, instead of using `insert` and repeatedly generating new
+-- | immutable records which need to be garbage collected.
+-- |
+-- | The `Category` instance for `Builder` can be used to compose builders.
+-- |
+-- | For example:
+-- |
+-- | ```purescript
+-- | build (insert x 42 >>> insert y "testing") {} :: { x :: Int, y :: String }
+-- | ```
+newtype Builder a b = Builder (a -> b)
+
+-- | Build a record, starting from some other record.
+build :: forall r1 r2. Builder (Record r1) (Record r2) -> Record r1 -> Record r2
+build (Builder b) r1 = b (copyRecord r1)
+
+derive newtype instance semigroupoidBuilder :: Semigroupoid Builder
+derive newtype instance categoryBuilder :: Category Builder
+
+-- | Build by inserting a new field.
+insert
+  :: forall l a r1 r2
+   . RowCons l a r1 r2
+  => RowLacks l r1
+  => IsSymbol l
+  => SProxy l
+  -> a
+  -> Builder (Record r1) (Record r2)
+insert l a = Builder \r1 -> unsafeInsert (reflectSymbol l) a r1
+
+-- | Build by deleting an existing field.
+delete
+  :: forall l a r1 r2
+   . IsSymbol l
+   => RowLacks l r1
+   => RowCons l a r1 r2
+   => SProxy l
+   -> Builder (Record r2) (Record r1)
+delete l = Builder \r2 -> unsafeDelete (reflectSymbol l) r2
+
+-- | Build by merging existing fields from another record.
+merge
+  :: forall r1 r2 r3
+   . Union r1 r2 r3
+  => Record r2
+  -> Builder (Record r1) (Record r3)
+merge r2 = Builder \r1 -> unsafeMerge r1 r2

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,6 +4,7 @@ import Prelude
 
 import Control.Monad.Eff (Eff)
 import Data.Record (delete, get, insert, modify, set)
+import Data.Record.Builder as Builder
 import Data.Symbol (SProxy(..))
 import Test.Assert (ASSERT, assert')
 
@@ -22,3 +23,10 @@ main = do
     get x (modify x (_ + 1) (set x 0 { x: 42 })) == 1
   assert' "delete, get" $
     get x (delete y { x: 42, y: 1337 }) == 42
+
+  let testBuilder = Builder.build (Builder.insert x 42
+                                  >>> Builder.merge { y: true, z: "testing" }
+                                  >>> Builder.delete y) {}
+
+  assert' "Data.Record.Builder" $
+    testBuilder.x == 42 && testBuilder.z == "testing"


### PR DESCRIPTION
Fixes #8.

Operations are safe since all arguments are used linearly and copied in `build`. Crucially, the `Builder` constructor is not exported.

Compare this to my [linear DSLs blog post](https://gist.github.com/paf31/7d589fe7c2b422f103882ace319601bb) or `purescript-substructural` by @rightfold.

This should make it simpler to write certain `RowList`-based operations, like mapping over, zipping or traversing records.