### PR TITLE
Homogeneous maps

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "purescript-symbols": "^3.0.0",
     "purescript-functions": "^3.0.0",
-    "purescript-typelevel-prelude": "^2.3.1",
+    "purescript-typelevel-prelude": "matthewleon/purescript-typelevel-prelude#homogeneous-sp",
     "purescript-st": "^3.0.0"
   },
   "devDependencies": {

--- a/src/Data/Record/Homogeneous.purs
+++ b/src/Data/Record/Homogeneous.purs
@@ -2,12 +2,16 @@ module Data.Record.Homogeneous
   ( mapValues
   , class MapValues
   , mapValuesImpl
+
+  , mapWithIndex
+  , class MapWithIndex
+  , mapWithIndexImpl
   ) where
 
 import Control.Category (id, (<<<))
 import Data.Record (get)
 import Data.Record.Builder (Builder, build, insert)
-import Data.Symbol (class IsSymbol, SProxy(..))
+import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 import Type.Row (class RowLacks, class RowToList, Cons, Nil, RLProxy(..))
 import Type.Row.Homogeneous (class Homogeneous, class HomogeneousRowList)
 
@@ -56,3 +60,49 @@ instance mapValuesNil
   => MapValues Nil row () fieldType fieldType'
   where
     mapValuesImpl _ _ _ = id
+
+mapWithIndex
+  :: forall r t r' t' fields
+   . RowToList r fields
+  => MapWithIndex fields r r' t t'
+  => (String -> t -> t')
+  -> Record r
+  -> Record r'
+mapWithIndex f r = build (mapWithIndexImpl (RLProxy :: RLProxy fields) f r) {}
+
+class ( Homogeneous row fieldType
+      , HomogeneousRowList rl fieldType
+      , Homogeneous row' fieldType'
+      )
+   <= MapWithIndex rl row row' fieldType fieldType'
+    | rl -> row'
+    , row' -> fieldType'
+    , row -> fieldType
+  where 
+    mapWithIndexImpl
+      :: RLProxy rl
+      -> (String -> fieldType -> fieldType')
+      -> Record row
+      -> Builder {} (Record row')
+
+instance mapWithIndexCons ::
+  ( MapWithIndex tail row tailRow' fieldType fieldType'
+  , Homogeneous row fieldType
+  , Homogeneous row' fieldType'
+  , IsSymbol name
+  , RowCons name fieldType tailRow row
+  , RowLacks name tailRow'
+  , RowCons name fieldType' tailRow' row'
+  ) => MapWithIndex (Cons name fieldType tail) row row' fieldType fieldType'
+  where
+    mapWithIndexImpl _ f record = insert nameP value <<< rest
+      where
+        nameP = SProxy :: SProxy name
+        rest = mapWithIndexImpl (RLProxy :: RLProxy tail) f record
+        value = f (reflectSymbol nameP) (get nameP record)
+
+instance mapWithIndexNil
+  :: Homogeneous row fieldType
+  => MapWithIndex Nil row () fieldType fieldType'
+  where
+    mapWithIndexImpl _ _ _ = id

--- a/src/Data/Record/Homogeneous.purs
+++ b/src/Data/Record/Homogeneous.purs
@@ -1,0 +1,43 @@
+module Data.Record.Homogeneous
+  ( mapValues
+  , class MapValues
+  , mapValuesImpl
+  ) where
+
+import Type.Row (class RowToList, Nil, RLProxy(..))
+import Type.Row.Homogeneous (class Homogeneous, class HomogeneousRowList)
+
+mapValues
+  :: forall r t r' t' fields
+   . RowToList r fields
+  => MapValues fields r r' t t'
+  => (t -> t')
+  -> Record r
+  -> Record r'
+mapValues f r = mapValuesImpl (RLProxy :: RLProxy fields) f r
+
+class ( Homogeneous row fieldType
+      , HomogeneousRowList rl fieldType
+      , Homogeneous row' fieldType'
+      )
+   <= MapValues rl row row' fieldType fieldType'
+    | rl -> row'
+    , row -> rl fieldType
+    , row'-> fieldType'
+  where 
+    mapValuesImpl
+      :: RLProxy rl
+      -> (fieldType -> fieldType')
+      -> Record row
+      -> Record row'
+
+instance mapValuesNil
+  :: Homogeneous row fieldType => MapValues Nil row () fieldType fieldType' where
+  mapValuesImpl _ _ _ = {}
+  
+
+{-
+mapRowListValues
+  ::
+   . HomogeneousRowList 
+-}

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,7 +5,7 @@ import Prelude
 import Control.Monad.Eff (Eff)
 import Data.Record (delete, equal, get, insert, modify, rename, set)
 import Data.Record.Builder as Builder
-import Data.Record.Homogeneous (mapValues)
+import Data.Record.Homogeneous (mapValues, mapWithIndex)
 import Data.Record.ST (pokeSTRecord, pureSTRecord, thawSTRecord)
 import Data.Record.Unsafe (unsafeHas)
 import Data.Symbol (SProxy(..))
@@ -39,6 +39,8 @@ main = do
     not $ unsafeHas "b" { a: 42 }
   assert' "mapValues" $
     mapValues (_ + 1) {a: 1, b: 2} `equal` {a: 2, b: 3}
+  assert' "mapWithIndex" $
+    mapWithIndex (\l v -> l <> show v) {a: 1, b: 2} `equal` {a: "a1", b: "b2"}
 
   let stTest1 = pureSTRecord do
         rec <- thawSTRecord { x: 41, y: "" }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,6 +5,7 @@ import Prelude
 import Control.Monad.Eff (Eff)
 import Data.Record (delete, equal, get, insert, modify, rename, set)
 import Data.Record.Builder as Builder
+import Data.Record.Homogeneous (mapValues)
 import Data.Record.ST (pokeSTRecord, pureSTRecord, thawSTRecord)
 import Data.Record.Unsafe (unsafeHas)
 import Data.Symbol (SProxy(..))
@@ -36,6 +37,8 @@ main = do
     unsafeHas "a" { a: 42 }
   assert' "unsafeHas2" $
     not $ unsafeHas "b" { a: 42 }
+  assert' "mapValues" $
+    mapValues (_ + 1) {a: 1, b: 2} `equal` {a: 2, b: 3}
 
   let stTest1 = pureSTRecord do
         rec <- thawSTRecord { x: 41, y: "" }


### PR DESCRIPTION
This is adapted from https://github.com/justinwoo/purescript-record-extra

I've changed a couple of things, adding the `Homogeneous` constraints and loosening the FunDeps a bit (please check if that makes sense).

Note that this depends on https://github.com/purescript/purescript-typelevel-prelude/pull/27

When that's merged, I'll update the bower file.

This is somewhat in response to the Issue here: https://github.com/purescript/purescript-record/issues/19

The last comment on there seems a bit ambiguous to me; I'm not sure if @paf31 wishes this kind of map to be kept in a separate repo or not... I do think having it here is quite handy. The next logical step after this would be maps and folds over labels and values, the latter of which would permit us to easily convert Records to, say, Maps, as has been discussed elsewhere.