### PR TITLE
Builder Profunctor instance

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
     "purescript-symbols": "^3.0.0",
     "purescript-functions": "^3.0.0",
     "purescript-typelevel-prelude": "^2.3.1",
-    "purescript-st": "^3.0.0"
+    "purescript-st": "^3.0.0",
+    "purescript-profunctor": "^3.2.0"
   },
   "devDependencies": {
     "purescript-assert": "^3.0.0"

--- a/src/Data/Record/Builder.purs
+++ b/src/Data/Record/Builder.purs
@@ -9,6 +9,7 @@ module Data.Record.Builder
 
 import Prelude
 
+import Data.Profunctor (class Profunctor)
 import Data.Symbol (class IsSymbol, SProxy, reflectSymbol)
 import Type.Row (class RowLacks)
 
@@ -37,6 +38,7 @@ build (Builder b) r1 = b (copyRecord r1)
 
 derive newtype instance semigroupoidBuilder :: Semigroupoid Builder
 derive newtype instance categoryBuilder :: Category Builder
+derive newtype instance profunctorBuilder :: Profunctor Builder
 
 -- | Build by inserting a new field.
 insert


### PR DESCRIPTION
addresses https://github.com/purescript/purescript-record/issues/32

This adds a dep on `purescript-profunctor`, making it breaking.