### PR TITLE
Add a well-typed merge function based on RowListNub

### DIFF
--- a/src/Data/Record/Unsafe.js
+++ b/src/Data/Record/Unsafe.js
@@ -28,3 +28,18 @@ exports.unsafeDeleteFn = function(label, rec) {
 exports.unsafeHasFn = function(label, rec) {
   return {}.hasOwnProperty.call(rec, label);
 };
+
+exports.unsafeMergeFn = function(r1, r2) {
+  var r = {};
+  for (var k1 in r2) {
+    if ({}.hasOwnProperty.call(r2, k1)) {
+      r[k1] = r2[k1];
+    }
+  }
+  for (var k2 in r1) {
+    if ({}.hasOwnProperty.call(r1, k2)) {
+      r[k2] = r1[k2];
+    }
+  }
+  return r;
+}

--- a/src/Data/Record/Unsafe.js
+++ b/src/Data/Record/Unsafe.js
@@ -42,4 +42,4 @@ exports.unsafeMergeFn = function(r1, r2) {
     }
   }
   return r;
-}
+};

--- a/src/Data/Record/Unsafe.purs
+++ b/src/Data/Record/Unsafe.purs
@@ -6,6 +6,8 @@ module Data.Record.Unsafe
   , unsafeGet
   , unsafeSet
   , unsafeDelete
+  , unsafeMerge
+  , unsafeMergeFn
   , unsafeHas
   ) where
 
@@ -14,6 +16,7 @@ import Data.Function.Uncurried (Fn2, Fn3, runFn2, runFn3)
 foreign import unsafeGetFn :: forall r a. Fn2 String (Record r) a
 foreign import unsafeSetFn :: forall r1 r2 a. Fn3 String a (Record r1) (Record r2)
 foreign import unsafeDeleteFn :: forall r1 r2. Fn2 String (Record r1) (Record r2)
+foreign import unsafeMergeFn :: forall r1 r2 r3. Fn2 (Record r1) (Record r2) (Record r3)
 foreign import unsafeHasFn :: forall r1. Fn2 String (Record r1) Boolean
 
 unsafeGet :: forall r a. String -> Record r -> a
@@ -24,6 +27,9 @@ unsafeSet = runFn3 unsafeSetFn
 
 unsafeDelete :: forall r1 r2. String -> Record r1 -> Record r2
 unsafeDelete = runFn2 unsafeDeleteFn
+
+unsafeMerge :: forall r1 r2 r3. Record r1 -> Record r2 -> Record r3
+unsafeMerge = runFn2 unsafeMergeFn
 
 unsafeHas :: forall r1. String -> Record r1 -> Boolean
 unsafeHas = runFn2 unsafeHasFn


### PR DESCRIPTION
Fixes #38 

`merge` does the right thing with duplicate labels (keeping those from the left record), while `merge'` helps inference by assuming that the records are disjoint (i.e. their union has no duplicates)