### PR TITLE
Add Builder.passThrough

### DIFF
--- a/src/Record/Builder.purs
+++ b/src/Record/Builder.purs
@@ -45,6 +45,10 @@ build (Builder b) r1 = b (copyRecord r1)
 derive newtype instance semigroupoidBuilder :: Semigroupoid Builder
 derive newtype instance categoryBuilder :: Category Builder
 
+-- | Pass the record through unchanged.
+passThrough :: forall r. Builder r r
+passThrough = identity
+
 -- | Build by inserting a new field.
 insert
   :: forall l a r1 r2


### PR DESCRIPTION
I have a use case where in one branch I want to insert a field using the record builder, while in another branch I want to keep it unchanged. This PR addresses the "keep it unchanged" part by adding the `passThrough` builder.