### PR TITLE
Drop typelevel-prelude dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,6 @@
     "purescript-functions": "^4.0.0",
     "purescript-prelude": "^4.1.0",
     "purescript-st": "^4.0.0",
-    "purescript-typelevel-prelude": "^4.0.0",
     "purescript-unsafe-coerce": "^4.0.0"
   },
   "devDependencies": {

--- a/src/Record.purs
+++ b/src/Record.purs
@@ -14,12 +14,15 @@ module Record
   , equalFields
   ) where
 
+import Prelude
+
 import Data.Function.Uncurried (runFn2)
+import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
+import Prim.Row (class Lacks, class Cons, class Nub, class Union)
+import Prim.RowList (class RowToList, kind RowList, Cons, Nil)
 import Record.Unsafe (unsafeGet, unsafeSet, unsafeDelete)
 import Record.Unsafe.Union (unsafeUnionFn)
-import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
-import Prelude (class Eq, (&&), (==))
-import Type.Row (class Lacks, class Cons, class Nub, class RowToList, class Union, Cons, Nil, RLProxy(RLProxy), kind RowList)
+import Type.Data.RowList (RLProxy(..))
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | Get a property for a label which is specified using a value-level proxy for

--- a/src/Record/Builder.purs
+++ b/src/Record/Builder.purs
@@ -15,8 +15,8 @@ import Prelude
 
 import Data.Function.Uncurried (runFn2)
 import Data.Symbol (class IsSymbol, SProxy, reflectSymbol)
+import Prim.Row as Row
 import Record.Unsafe.Union (unsafeUnionFn)
-import Type.Row as Row
 import Unsafe.Coerce (unsafeCoerce)
 
 foreign import copyRecord :: forall r1. Record r1 -> Record r1

--- a/test/Examples.purs
+++ b/test/Examples.purs
@@ -3,7 +3,7 @@ module Examples where
 import Prelude
 
 import Record as Record
-import Type.Prelude (SProxy(..))
+import Data.Symbol (SProxy(..))
 
 x_ = SProxy :: SProxy "x"
 y_ = SProxy :: SProxy "y"


### PR DESCRIPTION
We only use typelevel-prelude for its re-exports. Instead, we now import
Prim stuff directly from Prim, and import Prelude stuff directly from
Prelude.

Dropping the dependency is the easiest way of dealing with the major
version bump of v5.0.0 of typelevel-prelude (which is necessary for
v0.13.0 of the compiler).