### PR TITLE
Add roles declarations to allow safe coercions

### DIFF
--- a/src/Record/ST.purs
+++ b/src/Record/ST.purs
@@ -19,6 +19,8 @@ import Prim.Row as Row
 -- | Create values of type `STRecord` using `thaw`.
 foreign import data STRecord :: Region -> # Type -> Type
 
+type role STRecord nominal representational
+
 -- | Freeze a mutable record, creating a copy.
 foreign import freeze :: forall h r. STRecord h r -> ST h (Record r)
 


### PR DESCRIPTION
This allows terms of type `STRecord r a` to be coerced to type `STRecord r b` when `Coercible a b` holds, hence allowing the zero cost `coerce` instead of `map wrap` and `map unwrap` to introduce and eliminate newtypes under ST records for instance.

I couldn’t think of a case where a phantom roled region is an issue but in doubt I preferred to keep it nominal.