### PR TITLE
Override existing fields with Record.Builder.merge and Record.Builder.union

### DIFF
--- a/test/Main.purs
+++ b/test/Main.purs
@@ -63,3 +63,23 @@ main = do
 
   assert' "Record.Builder" $
     testBuilder.x == "42" && testBuilder.y == "testing"
+
+  assert' "Record.Builder.merge" $
+    let { x, y, z } = Builder.build (Builder.merge { x: 1, y: "y" }) { y: 2, z: true }
+          :: { x :: Int, y :: String, z :: Boolean }
+    in x == 1 && y == "y" && z
+
+  assert' "Record.Builder.union" $
+    let { x, y, z } = Builder.build (Builder.union { x: 1, y: "y" }) { y: 2, z: true }
+          :: { x :: Int, y :: String, y :: Int, z :: Boolean }
+    in x == 1 && y == "y" && z
+
+  assert' "Record.Builder.flip merge" $
+    let { x, y, z } = Builder.build (Builder.flip Builder.merge { x: 1, y: "y" }) { y: 2, z: true }
+          :: { x :: Int, y :: Int, z :: Boolean }
+    in x == 1 && y == 2 && z
+
+  assert' "Record.Builder.flip union" $
+    let { x, y, z } = Builder.build (Builder.flip Builder.union { x: 1, y: "y" }) { y: 2, z: true }
+          :: { x :: Int, y :: Int, y :: String, z :: Boolean }
+    in x == 1 && y == 2 && z


### PR DESCRIPTION
This pull request updates Record.Builder.merge and Record.Builder.union so that they behave more like Record.merge and Record.union: fields from the argument override those of the record being built in case of overlaps.

I also added a Record.Builder.flip function that can be used with both Record.Builder.merge and Record.Builder.union instead of renaming the existing Record.Builder.merge function to withDefaults and the existing Record.Builder.union to something else.

Closes https://github.com/purescript/purescript-record/issues/55.