### PR TITLE
Remove Record.ST.new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Breaking changes:
 
 New features:
 - Added `buildFromScratch` for building from an empty record (#53)
-- Added `new` and `run` to `Record.ST` (#71)
+- Added `run` to `Record.ST` (#71, #77)
 - Added `flip` function (#73)
 
 Bugfixes:

--- a/src/Record/ST.js
+++ b/src/Record/ST.js
@@ -4,10 +4,6 @@ exports.run = function (f) {
   return f();
 };
 
-exports["new"] = function () {
-  return {};
-};
-
 function copyRecord(rec) {
   var copy = {};
   for (var key in rec) {

--- a/src/Record/ST.purs
+++ b/src/Record/ST.purs
@@ -1,7 +1,6 @@
 module Record.ST
   ( STRecord
   , run
-  , new
   , freeze
   , thaw
   , peek
@@ -28,9 +27,6 @@ type role STRecord nominal representational
 -- |
 -- | The rank-2 type prevents the record from escaping the scope of `run`.
 foreign import run :: forall r. (forall h. ST h (STRecord h r)) -> Record r
-
--- | Create a new, empty mutable record
-foreign import new :: forall h. ST h (STRecord h ())
 
 -- | Freeze a mutable record, creating a copy.
 foreign import freeze :: forall h r. STRecord h r -> ST h (Record r)


### PR DESCRIPTION
**Description of the change**

There’s no way to add fields to a mutable record, this would require the ST monad to track the added fields with row indices, so Record.ST.new can only be frozen with Record.ST.freeze or Record.ST.run, which is lot less convenient than `{}` 😅

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
