### PR TITLE
Skip copyRecord for buildFromScratch in Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Skipped needing to copy initiial record for `buildFromScratch`. (#80)
 
 ## [v3.0.0](https://github.com/purescript/purescript-record/releases/tag/v3.0.0) - 2021-02-26
 

--- a/src/Record/Builder.purs
+++ b/src/Record/Builder.purs
@@ -15,7 +15,6 @@ module Record.Builder
 
 import Prelude hiding (flip)
 
-import Data.Function (flip) as Function
 import Data.Function.Uncurried (runFn2)
 import Data.Symbol (class IsSymbol, reflectSymbol)
 import Prim.Row as Row
@@ -50,7 +49,7 @@ build (Builder b) r1 = b (copyRecord r1)
 
 -- | Build a record from scratch.
 buildFromScratch :: forall r. Builder (Record ()) (Record r) -> Record r
-buildFromScratch = Function.flip build {}
+buildFromScratch (Builder b) = b {}
 
 -- | Flip a function of one argument returning a builder.
 flip :: forall r1 r2 r3. (Record r1 -> Builder (Record r2) (Record r3)) -> Record r2 -> Builder (Record r1) (Record r3)


### PR DESCRIPTION
**Description of the change**

Skip needing to copyRecord for `buildFromScratch`.

---

**Checklist:**

- [X] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
